### PR TITLE
Refactor p4c Bazel rule and make sure it works using CI and example project.

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,3 @@
+# Exclude bazel sub-projects so `bazel build //...` works.
+control-plane/p4runtime
+test/frameworks/gtest

--- a/.github/workflows/ci-bazel.yml
+++ b/.github/workflows/ci-bazel.yml
@@ -1,0 +1,38 @@
+name: "Bazel"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      BAZEL: bazelisk-linux-amd64
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    
+    - name: Mount bazel cache
+      uses: actions/cache@v2
+      with:
+        path: "~/.cache/bazel"  # See https://docs.bazel.build/versions/master/output_directories.html
+        key: bazel
+
+    - name: Install bazelisk
+      run: |
+        curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.4.0/$BAZEL"
+        chmod +x $BAZEL
+        sudo mv $BAZEL /usr/local/bin/bazel
+
+    - name: Install Flex and GMP
+      run: sudo apt-get update && sudo apt-get install flex libgmp-dev
+
+    - name: Build p4c
+      run: bazel build //... --verbose_failures
+
+    - name: Build bazel/example
+      run: cd ./bazel/example && bazel build //... --verbose_failures

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,9 +1,14 @@
-load("@//:bazel/lex.bzl", "genlex")
-load("@//:bazel/bison.bzl", "genyacc")
+load("//:bazel/flex.bzl", "genlex")
+load("//:bazel/bison.bzl", "genyacc")
 
 package(
     default_visibility = ["//visibility:public"],
-    license = "notice",  # Apache v2
+    licenses = ["notice"],  # Apache v2
+)
+
+filegroup(
+    name = "p4include",
+    srcs = glob(["p4include/*.p4"]),
 )
 
 P4C_BUILD_DEFAULT_COPTS = [

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -2,20 +2,6 @@ workspace(name = "com_github_p4lang_p4c")
 
 # -- Direct dependencies. ------------------------------------------------------
 
-# Cannot currently put this in `p4c_deps` as it requires relative path;
-# see https://github.com/bazelbuild/bazel/issues/11573.
-local_repository(
-    name = "com_github_p4lang_p4runtime",
-    path = "control-plane/p4runtime/proto",
-)
-
-# Cannot currently put this in `p4c_deps` as it requires relative path;
-# see https://github.com/bazelbuild/bazel/issues/11573.
-local_repository(
-    name = "com_google_googletest",
-    path = "test/frameworks/gtest",
-)
-
 load("//:bazel/p4c_deps.bzl", "p4c_deps")
 
 p4c_deps()

--- a/bazel/example/BUILD.bazel
+++ b/bazel/example/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@com_github_p4lang_p4c//:bazel/build_defs.bzl", "p4_library")
+load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
 
 p4_library(
   name = "program",

--- a/bazel/example/BUILD.bazel
+++ b/bazel/example/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@com_github_p4lang_p4c//:bazel/build_defs.bzl", "p4_library")
+
+p4_library(
+  name = "program",
+  src = "program.p4",
+  deps = [],                          # Optional: #include-ed dependencies.
+  p4info_out = "program.p4info.txt",  # Optional.
+  target = "bmv2",                    # Optional (default: "bmv2").
+  target_out = "program.bmv2.json",   # Optional.
+  arch = "v1model",                   # Optional (default: "v1model").
+)
+
+p4_library(
+  name = "program_fewer_args",
+  src = "program.p4",
+  p4info_out = "program.p4info.2.txt",
+)

--- a/bazel/example/WORKSPACE.bazel
+++ b/bazel/example/WORKSPACE.bazel
@@ -1,22 +1,11 @@
-workspace(name = "com_github_p4lang_p4c")
+workspace(name = "example_p4_project")
 
-# -- Direct dependencies. ------------------------------------------------------
-
-# Cannot currently put this in `p4c_deps` as it requires relative path;
-# see https://github.com/bazelbuild/bazel/issues/11573.
 local_repository(
-    name = "com_github_p4lang_p4runtime",
-    path = "control-plane/p4runtime/proto",
+  name = "com_github_p4lang_p4c",
+  path = "../..",
 )
 
-# Cannot currently put this in `p4c_deps` as it requires relative path;
-# see https://github.com/bazelbuild/bazel/issues/11573.
-local_repository(
-    name = "com_google_googletest",
-    path = "test/frameworks/gtest",
-)
-
-load("//:bazel/p4c_deps.bzl", "p4c_deps")
+load("@com_github_p4lang_p4c//:bazel/p4c_deps.bzl", "p4c_deps")
 
 p4c_deps()
 

--- a/bazel/example/program.p4
+++ b/bazel/example/program.p4
@@ -1,0 +1,130 @@
+// Taken from https://p4.org/p4/getting-started-with-p4.html.
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<48> EthernetAddress;
+typedef bit<32> IPv4Address;
+
+header ethernet_t {
+    EthernetAddress dst_addr;
+    EthernetAddress src_addr;
+    bit<16>         ether_type;
+}
+
+header ipv4_t {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     total_len;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     frag_offset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdr_checksum;
+    IPv4Address src_addr;
+    IPv4Address dst_addr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct metadata_t {
+}
+
+error {
+    IPv4IncorrectVersion,
+    IPv4OptionsNotSupported
+}
+
+parser my_parser(packet_in packet,
+                out headers_t hd,
+                inout metadata_t meta,
+                inout standard_metadata_t standard_meta)
+{
+    state start {
+        packet.extract(hd.ethernet);
+        transition select(hd.ethernet.ether_type) {
+            0x0800:  parse_ipv4;
+            default: accept;
+        }
+    }
+
+    state parse_ipv4 {
+        packet.extract(hd.ipv4);
+        verify(hd.ipv4.version == 4w4, error.IPv4IncorrectVersion);
+        verify(hd.ipv4.ihl == 4w5, error.IPv4OptionsNotSupported);
+        transition accept;
+    }    
+}
+
+control my_deparser(packet_out packet,
+                   in headers_t hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control my_verify_checksum(inout headers_t hdr,
+                         inout metadata_t meta)
+{
+    apply { }
+}
+
+control my_compute_checksum(inout headers_t hdr,
+                          inout metadata_t meta)
+{
+    apply { }
+}
+
+control my_ingress(inout headers_t hdr,
+                  inout metadata_t meta,
+                  inout standard_metadata_t standard_metadata)
+{
+    bool dropped = false;
+
+    action drop_action() {
+        mark_to_drop(standard_metadata);
+        dropped = true;
+    }
+
+    action to_port_action(bit<9> port) {
+        hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
+        standard_metadata.egress_spec = port;
+    }
+
+    table ipv4_match {
+        key = {
+            hdr.ipv4.dst_addr: lpm;
+        }
+        actions = {
+            drop_action;
+            to_port_action;
+        }
+        size = 1024;
+        default_action = drop_action;
+    }
+
+    apply {
+        ipv4_match.apply();
+        if (dropped) return;
+    }
+}
+
+control my_egress(inout headers_t hdr,
+                 inout metadata_t meta,
+                 inout standard_metadata_t standard_metadata)
+{
+    apply { }
+}
+
+V1Switch(my_parser(),
+         my_verify_checksum(),
+         my_ingress(),
+         my_egress(),
+         my_compute_checksum(),
+         my_deparser()) main;

--- a/bazel/flex.bzl
+++ b/bazel/flex.bzl
@@ -1,11 +1,8 @@
-# Definition of genlex and genyacc.
+"""Build rule for generating C or C++ sources with Flex."""
 
-"""Build rule for generating C or C++ sources with Flex.
-"""
-
-# Expects to find flex in the path
-def genlex(name, src, out, prefix, includes = [], visibility = []):
-    """One-line summary: Generate a C++ lexer from a lex file using Flex.
+# Expects to find flex in the path.
+def genlex(name, src, out, prefix, includes = [], visibility = None):
+    """Generate a C++ lexer from a lex file using Flex.
 
     Args:
       name: The name of the rule.

--- a/bazel/p4c_deps.bzl
+++ b/bazel/p4c_deps.bzl
@@ -6,9 +6,13 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def p4c_deps():
     """Loads dependencies need to compile p4c."""
     if not native.existing_rule("com_github_p4lang_p4runtime"):
-        native.local_repository(
+        http_archive(
             name = "com_github_p4lang_p4runtime",
-            path = "control-plane/p4runtime/proto",
+            # TODO(smolkaj): Set this to something more permanent once
+            # https://github.com/p4lang/p4runtime/pull/297 has been merged.
+            urls = ["https://github.com/p4lang/p4runtime/archive/bazel.zip"],
+            strip_prefix = "p4runtime-bazel/proto",
+            sha256 = "69db7d93730c30aeb99da247f941ce8a80a403354e98079f5a5b9500a9a389b9",
         )
     if not native.existing_rule("com_github_nelhage_rules_boost"):
         git_repository(
@@ -18,14 +22,16 @@ def p4c_deps():
             shallow_since = "1576879360 -0800",
         )
     if not native.existing_rule("com_google_googletest"):
-        native.local_repository(
+        http_archive(
             name = "com_google_googletest",
-            path = "test/frameworks/gtest",
+            urls = ["https://github.com/google/googletest/archive/release-1.10.0.tar.gz"],
+            strip_prefix = "googletest-release-1.10.0",
+            sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
         )
     if not native.existing_rule("bison"):
         http_archive(
             name = "bison",
-            build_file = "//:bazel/bison.BUILD.bazel",
+            build_file = "@com_github_p4lang_p4c//:bazel/bison.BUILD.bazel",
             sha256 = "0b36200b9868ee289b78cefd1199496b02b76899bbb7e84ff1c0733a991313d1",
             strip_prefix = "bison-3.5",
             urls = ["https://ftp.gnu.org/gnu/bison/bison-3.5.tar.gz"],
@@ -33,9 +39,9 @@ def p4c_deps():
     if not native.existing_rule("m4"):
         http_archive(
             name = "m4",
-            build_file = "//:bazel/m4.BUILD.bazel",
+            build_file = "@com_github_p4lang_p4c//:bazel/m4.BUILD.bazel",
             patch_args = ["-p1"],
-            patches = ["//:bazel/m4.patch"],
+            patches = ["@com_github_p4lang_p4c//:bazel/m4.patch"],
             sha256 = "ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab",
             strip_prefix = "m4-1.4.18",
             urls = ["https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.gz"],

--- a/bazel/p4c_deps.bzl
+++ b/bazel/p4c_deps.bzl
@@ -6,13 +6,25 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def p4c_deps():
     """Loads dependencies need to compile p4c."""
     if not native.existing_rule("com_github_p4lang_p4runtime"):
-        http_archive(
+        # Cannot currently use local_repository due to Bazel limitation,
+        # see https://github.com/bazelbuild/bazel/issues/11573.
+        #
+        # native.local_repository(
+        #     name = "com_github_p4lang_p4runtime",
+        #     path = "@com_github_p4lang_p4c//:control-plane/p4runtime/proto",
+        # )
+        #
+        # We use git_repository as a workaround; the version used here should
+        # ideally be kept in sync with the submodule control-plane/p4runtime.
+        git_repository(
             name = "com_github_p4lang_p4runtime",
-            # TODO(smolkaj): Set this to something more permanent once
-            # https://github.com/p4lang/p4runtime/pull/297 has been merged.
-            urls = ["https://github.com/p4lang/p4runtime/archive/bazel.zip"],
-            strip_prefix = "p4runtime-bazel/proto",
-            sha256 = "69db7d93730c30aeb99da247f941ce8a80a403354e98079f5a5b9500a9a389b9",
+            remote = "https://github.com/p4lang/p4runtime",
+            commit = "776797d4bc7c2e5f1a7249f73f1c879a91688e75",
+            shallow_since = "1591811258 -0700",
+            # strip_prefix is broken; we use patch_cmds as a workaround,
+            # see https://github.com/bazelbuild/bazel/issues/10062.
+            patch_cmds = ["mv proto/* ."],
+            # strip_prefix = "proto",  # Broken.
         )
     if not native.existing_rule("com_github_nelhage_rules_boost"):
         git_repository(
@@ -22,6 +34,16 @@ def p4c_deps():
             shallow_since = "1576879360 -0800",
         )
     if not native.existing_rule("com_google_googletest"):
+        # Cannot currently use local_repository due to Bazel limitation,
+        # see https://github.com/bazelbuild/bazel/issues/11573.
+        #
+        # local_repository(
+        #     name = "com_google_googletest",
+        #     path = "@com_github_p4lang_p4c//:test/frameworks/gtest",
+        # )
+        #
+        # We use http_archive as a workaround; the version used here should
+        # ideally be kept in sync with the submodule test/frameworks/gtest.
         http_archive(
             name = "com_google_googletest",
             urls = ["https://github.com/google/googletest/archive/release-1.10.0.tar.gz"],


### PR DESCRIPTION
* Use local repositories for local build, but fall back to git repositories for
  3rd party build. This is necessary due to
  https://github.com/bazelbuild/bazel/issues/11573

* Rename lex -> flex.

* Ignore bazel sub-projects so `bazel build //...` works.